### PR TITLE
Fixed "Object doesn't support..." error in IE8

### DIFF
--- a/jquery.DataSaver.js
+++ b/jquery.DataSaver.js
@@ -40,6 +40,8 @@
 
 		if (typeof key === "undefined") {
 			var url = {};
+			window.location.hasOwnProperty = window.location.hasOwnProperty || Object.prototype.hasOwnProperty;
+
 			$.each(this.options.keyUrlAttrs, function(index, value){
 				if (window.location.hasOwnProperty(value)) {
 					url[value] = window.location[value];


### PR DESCRIPTION
IE8 (at least in IETester) would kick the error "Object doesn't support
this property or method" when running "window.location.hasOwnProperty"

(Fix taken from
http://perrymitchell.net/article/ie8_javascript_indexof_hasownproperty/)

(This is my first pull request. If I did it wrong, I can redo it.)
